### PR TITLE
Added a function to turn on the oven lights, updated ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ While operating in native mode, the developer must adhere to the following rules
     - [range.glassTouchErrors](#rangeglasstoucherrors)
     - [range.leds](#rangeleds)
     - [range.buzzerTone](#rangebuzzertone)
+    - [range.ovenLight](#rangeoventlight)
 1. [Appendix](#appendix)
     - [Enabled state](#enabled-state)
     - [Probe presence](#probe-presence)
@@ -1024,6 +1025,17 @@ greenBean.connect("range", function(range) {
 });
 ```
 
+#### *range.ovenLight*
+The oven light is a write-only integer value of (0 = Off or 1 = On).
+*Note that this functionality is only available in FCT mode (see [range.fctMode](#rangefctmode) above).*
+
+``` javascript
+var greenBean = require("green-bean");
+
+greenBean.connect("range", function(range) {
+    range.ovenLight.write(1);
+});
+```
 ### Appendix
 
 #### Enabled state

--- a/index.js
+++ b/index.js
@@ -289,7 +289,12 @@ function Range (bus, appliance, base) {
         command: 0xb5,
         format: "UInt8"
     });
-    
+
+    appliance.ovenLight = appliance.command({
+        command: 0x71,
+        format: "UInt8"
+    });
+        
     return appliance;
 }
 


### PR DESCRIPTION
I needed to turn on the oven light for coffee Roasting and had no way to do this. Worked with Myles to add this function in FCT mode. Works great!
